### PR TITLE
Add support for retrieval of testing API key through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ Structure it as follows, adding your API keys:
   "secret": "mysecret"
 }
 ```
+
+As an alternative, you can pass BitTrex credentials using these environment
+variables:
+* BITTREX_API_KEY
+* BITTREX_API_SECRET

--- a/bittrex/test/bittrex_tests.py
+++ b/bittrex/test/bittrex_tests.py
@@ -2,6 +2,8 @@ __author__ = 'eric'
 
 import unittest
 import json
+import os
+
 from bittrex.bittrex import Bittrex
 
 
@@ -63,9 +65,16 @@ class TestBittrexAccountAPI(unittest.TestCase):
     }
     """
     def setUp(self):
-        with open("secrets.json") as secrets_file:
-            self.secrets = json.load(secrets_file)
-            secrets_file.close()
+        if 'BITTREX_API_KEY' in os.environ \
+                and 'BITTREX_API_SECRET' in os.environ:
+            self.secrets = {
+                'key': os.environ['BITTREX_API_KEY'],
+                'secret': os.environ['BITTREX_API_SECRET'],
+            }
+        else:
+            with open("secrets.json") as secrets_file:
+                self.secrets = json.load(secrets_file)
+
         self.bittrex = Bittrex(self.secrets['key'], self.secrets['secret'])
 
     def test_handles_invalid_key_or_secret(self):


### PR DESCRIPTION
Because I don't want to write them in a cleartext file. ;-)